### PR TITLE
Add ST version of MonadObjective.

### DIFF
--- a/objective.cabal
+++ b/objective.cabal
@@ -17,7 +17,11 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Control.Object, Control.Monad.Objective.Class, Control.Monad.Objective.IO, Control.Monad.Objective
+  exposed-modules:     Control.Object
+                     , Control.Monad.Objective
+                     , Control.Monad.Objective.Class
+                     , Control.Monad.Objective.IO
+                     , Control.Monad.Objective.ST
   -- other-modules:       
   other-extensions:    MultiParamTypeClasses, KindSignatures, TypeFamilies
   build-depends:       base >=4.5 && <5, transformers >= 0.3 && <0.5, free >= 4.0 && <5, clean-unions < 0.2, profunctors > 4.0 && <5

--- a/src/Control/Monad/Objective/ST.hs
+++ b/src/Control/Monad/Objective/ST.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Objective.ST
+-- Copyright   :  (c) Corbin Simpson, Google Inc. 2014
+-- License     :  BSD3
+--
+-- Maintainer  :  Fumiaki Kinoshita <fumiexcel@gmail.com>
+-- Stability   :  experimental
+-- Portability :  non-portable (ST)
+--
+-- 'MonadObjective' 'ST' using 'STRef'
+--
+-----------------------------------------------------------------------------
+module Control.Monad.Objective.ST where
+
+import Control.Monad.Objective.Class
+import Control.Monad.ST
+import Control.Object
+import Data.STRef
+
+instance MonadObjective (ST s) where
+    type Residence (ST s) = ST s
+    data Address e (ST s) = Address (STRef s (Object e (ST s)))
+
+    Address ref .- e = do
+        o <- readSTRef ref
+        (a, o') <- runObject o e
+        writeSTRef ref o'
+        return a
+    new o = Address `fmap` newSTRef o


### PR DESCRIPTION
ST is convenient to have as a base Monad because of its totally-encapsulated effects.

Signed-off-by: Corbin Simpson cds@corbinsimpson.com simpsoco@google.com

As lightly discussed on IRC.
