### PR TITLE
Make invokeOn exception safe

### DIFF
--- a/objective.cabal
+++ b/objective.cabal
@@ -30,6 +30,7 @@ library
   other-extensions:    MultiParamTypeClasses, KindSignatures, TypeFamilies
   build-depends:       base >=4.6 && <5
     , either >= 4.3 && <4.5
+    , exceptions >= 0.8
     , containers >= 0.5.0.0 && <0.6
     , unordered-containers >= 0.2.0.0 && <0.3
     , transformers >= 0.3


### PR DESCRIPTION
In order to allow this to happen, we need to strengthen the typeclass
constraint from MonadIO to MonadMask. Another alternative is to use
MonadBaseControl, but generally MonadMask seems to be more widely
accepted.