### PR TITLE
Fix proofs/composition.md

### DIFF
--- a/proofs/composition.md
+++ b/proofs/composition.md
@@ -27,7 +27,7 @@ fmap (joinO . joinO) . outO c . outO b . outO a
 
 ```haskell
 outO ((a @>>@ b) @>>@ c)
-= { (@>>@)の定義 }
+= { Definition of (@>>@) }
 fmap joinO . outO c . (fmap joinO . outO b . outO a) f
 = { outO . inO = id }
 fmap joinO . outO c . fmap joinO . outO b . outO a


### PR DESCRIPTION
I fixed `proofs/composition.md` because Japanese is mixed in it.