### PR TITLE
Fix Control.Object.Mortal

### DIFF
--- a/objective.cabal
+++ b/objective.cabal
@@ -29,6 +29,7 @@ library
       , Data.Functor.Request
   other-extensions:    MultiParamTypeClasses, KindSignatures, TypeFamilies
   build-depends:       base >=4.6 && <5
+    , bifunctors
     , exceptions >= 0.8
     , containers >= 0.5.0.0 && <0.6
     , unordered-containers >= 0.2.0.0 && <0.3

--- a/src/Control/Object/Mortal.hs
+++ b/src/Control/Object/Mortal.hs
@@ -72,13 +72,13 @@ instance MonadTrans (Mortal f) where
   {-# INLINE lift #-}
 
 -- | Construct a mortal in a 'Object' construction manner.
-mortal :: (Functor m, Monad m) => (forall x. f x -> ExceptT a m (x, Mortal f m a)) -> Mortal f m a
-mortal f = unsafeCoerce f `asTypeOf` Mortal (Object (fmap (fmap unMortal) . f))
+mortal :: Monad m => (forall x. f x -> ExceptT a m (x, Mortal f m a)) -> Mortal f m a
+mortal f = unsafeCoerce f `asTypeOf` Mortal (Object (liftM (liftM unMortal) . f))
 {-# INLINE mortal #-}
 
 -- | Send a message to a mortal.
-runMortal :: (Functor m, Monad m) => Mortal f m a -> f x -> ExceptT a m (x, Mortal f m a)
-runMortal = unsafeCoerce `asTypeOf` ((fmap (fmap Mortal) . ) . runObject . unMortal)
+runMortal :: Monad m => Mortal f m a -> f x -> ExceptT a m (x, Mortal f m a)
+runMortal = unsafeCoerce `asTypeOf` ((liftM (liftM Mortal) . ) . runObject . unMortal)
 {-# INLINE runMortal #-}
 
 -- | Restricted 'Mortal' constuctor which can be applied to 'transit', 'fromFoldable' without ambiguousness.
@@ -87,7 +87,7 @@ mortal_ = Mortal
 {-# INLINE mortal_ #-}
 
 -- | Turn an object into a mortal without death.
-immortal :: (Functor m, Monad m) => Object f m -> Mortal f m x
+immortal :: Monad m => Object f m -> Mortal f m x
 immortal obj = Mortal (obj @>>^ lift)
 {-# INLINE immortal #-}
 

--- a/src/Control/Object/Mortal.hs
+++ b/src/Control/Object/Mortal.hs
@@ -73,12 +73,12 @@ instance MonadTrans (Mortal f) where
 
 -- | Construct a mortal in a 'Object' construction manner.
 mortal :: Monad m => (forall x. f x -> ExceptT a m (x, Mortal f m a)) -> Mortal f m a
-mortal f = unsafeCoerce f `asTypeOf` Mortal (Object (liftM (liftM unMortal) . f))
+mortal f = unsafeCoerce f `asTypeOf` Mortal (Object (liftM (fmap unMortal) . f))
 {-# INLINE mortal #-}
 
 -- | Send a message to a mortal.
 runMortal :: Monad m => Mortal f m a -> f x -> ExceptT a m (x, Mortal f m a)
-runMortal = unsafeCoerce `asTypeOf` ((liftM (liftM Mortal) . ) . runObject . unMortal)
+runMortal = unsafeCoerce `asTypeOf` ((liftM (fmap Mortal) . ) . runObject . unMortal)
 {-# INLINE runMortal #-}
 
 -- | Restricted 'Mortal' constuctor which can be applied to 'transit', 'fromFoldable' without ambiguousness.

--- a/src/Control/Object/Mortal.hs
+++ b/src/Control/Object/Mortal.hs
@@ -87,7 +87,7 @@ mortal_ = Mortal
 {-# INLINE mortal_ #-}
 
 -- | Turn an object into a mortal without death.
-immortal :: Monad m => Object f m -> Mortal f m x
+immortal :: (Functor m, Monad m) => Object f m -> Mortal f m x
 immortal obj = Mortal (obj @>>^ lift)
 {-# INLINE immortal #-}
 

--- a/src/Control/Object/Mortal.hs
+++ b/src/Control/Object/Mortal.hs
@@ -72,12 +72,12 @@ instance MonadTrans (Mortal f) where
   {-# INLINE lift #-}
 
 -- | Construct a mortal in a 'Object' construction manner.
-mortal :: Monad m => (forall x. f x -> ExceptT a m (x, Mortal f m a)) -> Mortal f m a
+mortal :: (Functor m, Monad m) => (forall x. f x -> ExceptT a m (x, Mortal f m a)) -> Mortal f m a
 mortal f = unsafeCoerce f `asTypeOf` Mortal (Object (fmap (fmap unMortal) . f))
 {-# INLINE mortal #-}
 
 -- | Send a message to a mortal.
-runMortal :: Monad m => Mortal f m a -> f x -> ExceptT a m (x, Mortal f m a)
+runMortal :: (Functor m, Monad m) => Mortal f m a -> f x -> ExceptT a m (x, Mortal f m a)
 runMortal = unsafeCoerce `asTypeOf` ((fmap (fmap Mortal) . ) . runObject . unMortal)
 {-# INLINE runMortal #-}
 
@@ -87,7 +87,7 @@ mortal_ = Mortal
 {-# INLINE mortal_ #-}
 
 -- | Turn an object into a mortal without death.
-immortal :: Monad m => Object f m -> Mortal f m x
+immortal :: (Functor m, Monad m) => Object f m -> Mortal f m x
 immortal obj = Mortal (obj @>>^ lift)
 {-# INLINE immortal #-}
 


### PR DESCRIPTION
[objective-1.1.2 failed to build](https://matrix.hackage.haskell.org/package/objective) in GHC-7.8 and 7.6. And, [it also failed in Travis CI](https://travis-ci.org/fumieval/objective/builds/318919322). This pull request fix the issue.